### PR TITLE
Create "hourly" workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Quantified CM Automator
+
+## Setting up a Codespace
+
+Unfortunately, I've not found a way for Codespaces to use workload identity for authentication (as we can with GitHub Actions), so the deployment service account's key is available via a Codespace secret. Run the following when starting a new Codespace:
+
+```
+echo ${DEPLOYER_SERVICE_ACCOUNT_KEY} > ${CODESPACE_VSCODE_FOLDER}/creds.json
+export GOOGLE_APPLICATION_CREDENTIALS=${CODESPACE_VSCODE_FOLDER}/creds.json
+pushd ${CODESPACE_VSCODE_FOLDER}/terraform
+terraform init -reconfigure
+popd
+```

--- a/terraform/fitbit.tf
+++ b/terraform/fitbit.tf
@@ -89,21 +89,3 @@ resource "google_bigquery_dataset_access" "raw_data_fitbit" {
     }
   }
 }
-
-resource "google_cloud_scheduler_job" "fitbit_sleep" {
-  project     = google_project_service.cloudscheduler.project
-  name        = "fitbit-sleep"
-  description = "Trigger fetching sleep data from FitBit"
-  schedule    = "5 1 * * *"
-  time_zone   = "America/New_York"
-
-  http_target {
-    http_method = "POST"
-    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.fitbit_sleep.id}/executions"
-    body        = base64encode(jsonencode({ argument = "{}" }))
-
-    oauth_token {
-      service_account_email = google_service_account.scheduler.email
-    }
-  }
-}

--- a/terraform/goodreads.tf
+++ b/terraform/goodreads.tf
@@ -22,22 +22,6 @@ resource "google_project_iam_binding" "goodreads" {
   members = [google_service_account.goodreads.member]
 }
 
-resource "google_workflows_workflow" "goodreads" {
-  project         = google_project_service.workflows.project
-  name            = "goodreads"
-  service_account = google_service_account.goodreads.email
-  # The workflow's very simple, so embed it rather than referencing a yaml file
-  source_contents = <<-EOT
-    main:
-      steps:
-      - run:
-          call: googleapis.run.v2.projects.locations.jobs.run
-          args:
-            name: ${google_cloud_run_v2_job.fetch_goodreads.id}
-            body: {}
-  EOT
-}
-
 resource "google_storage_bucket" "goodreads_scripts" {
   name                        = "${google_project_service.storage.project}-goodreads-scripts"
   location                    = "US"
@@ -158,5 +142,5 @@ resource "google_cloud_run_v2_job_iam_binding" "fetch_goodreads_invokers" {
   name     = google_cloud_run_v2_job.fetch_goodreads.name
   location = google_cloud_run_v2_job.fetch_goodreads.location
   role     = "roles/run.invoker"
-  members  = [google_service_account.goodreads.member]
+  members  = [google_service_account.scheduler.member]
 }

--- a/terraform/workflows.tf
+++ b/terraform/workflows.tf
@@ -8,6 +8,13 @@ resource "google_project_iam_member" "scheduler_triggers_workflows" {
   member  = google_service_account.scheduler.member
 }
 
+# Allow the scheduler to see jobs it kicked off
+resource "google_project_iam_member" "scheduler_sees_cloud_run" {
+  project = google_project_service.cloudscheduler.project
+  role    = "roles/run.viewer"
+  member  = google_service_account.scheduler.member
+}
+
 resource "google_workflows_workflow" "hourly" {
   project         = google_project_service.workflows.project
   name            = "hourly"
@@ -16,6 +23,7 @@ resource "google_workflows_workflow" "hourly" {
 
   user_env_vars = {
     FITBIT_SLEEP_WORKFLOW_ID = google_workflows_workflow.fitbit_sleep.name
+    GOODREADS_CLOUD_RUN_ID   = google_cloud_run_v2_job.fetch_goodreads.id
   }
 }
 

--- a/terraform/workflows.tf
+++ b/terraform/workflows.tf
@@ -7,3 +7,31 @@ resource "google_project_iam_member" "scheduler_triggers_workflows" {
   role    = "roles/workflows.invoker"
   member  = google_service_account.scheduler.member
 }
+
+resource "google_workflows_workflow" "hourly" {
+  project         = google_project_service.workflows.project
+  name            = "hourly"
+  service_account = google_service_account.scheduler.email
+  source_contents = file("../workflows/hourly.workflows.yml")
+
+  user_env_vars = {
+    FITBIT_SLEEP_WORKFLOW_ID = google_workflows_workflow.fitbit_sleep.name
+  }
+}
+
+resource "google_cloud_scheduler_job" "hourly" {
+  project     = google_project_service.cloudscheduler.project
+  name        = "hourly"
+  description = "Trigger the 'hourly' workflow, every hour"
+  schedule    = "5 * * * *"
+  time_zone   = "America/New_York"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.hourly.id}/executions"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+}

--- a/workflows/fitbit/sleep.workflows.yml
+++ b/workflows/fitbit/sleep.workflows.yml
@@ -3,6 +3,9 @@ main:
   steps:
   - init_after_date:
       switch:
+      - condition: ${get_type(args) != "map"}
+        call: fetch_latest_date
+        result: after_date
       - condition: ${"after_date" in args}
         assign:
         - after_date: ${args.after_date}

--- a/workflows/hourly.workflows.yml
+++ b/workflows/hourly.workflows.yml
@@ -1,0 +1,16 @@
+main:
+  steps:
+    - parse_time:
+        assign:
+          - timestamp_str: ${time.format(sys.now(), "America/New_York")}
+          - time_str: ${text.split(timestamp_str, "T")[1]}
+          - hour_str: ${text.split(time_str, ":")[0]}
+          - hour: ${int(hour_str)}
+    - fitbit_sleep:
+        switch:
+          - condition: ${hour == 1}
+            call: googleapis.workflowexecutions.v1.projects.locations.workflows.executions.run
+            args:
+              project_id: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+              location: ${sys.get_env("GOOGLE_CLOUD_LOCATION")}
+              workflow_id: ${sys.get_env("FITBIT_SLEEP_WORKFLOW_ID")}

--- a/workflows/hourly.workflows.yml
+++ b/workflows/hourly.workflows.yml
@@ -14,3 +14,10 @@ main:
               project_id: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
               location: ${sys.get_env("GOOGLE_CLOUD_LOCATION")}
               workflow_id: ${sys.get_env("FITBIT_SLEEP_WORKFLOW_ID")}
+    - goodreads:
+        switch:
+          - condition: ${hour == 2}
+            call: googleapis.run.v2.projects.locations.jobs.run
+            args:
+              name: ${sys.get_env("GOODREADS_CLOUD_RUN_ID")}
+              body: {}


### PR DESCRIPTION
It's pretty silly, but cloud scheduler jobs are 10 cents per month. Using a workflow that runs hourly saves a little bit (particularly if there are a ton of little jobs, which is the plan).