### PR TITLE
Track GitHub events.

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,0 +1,30 @@
+resource "google_service_account" "github" {
+  account_id = "github"
+}
+
+resource "google_secret_manager_secret" "github_token" {
+  project   = google_project_service.secretmanager.project
+  secret_id = "github_token"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_binding" "github_token_access" {
+  secret_id = google_secret_manager_secret.github_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  members   = [google_service_account.github.member]
+}
+
+resource "google_project_iam_member" "github_logging" {
+  project = google_project_service.logging.project
+  role    = "roles/logging.logWriter"
+  member  = google_service_account.github.member
+}
+
+resource "google_workflows_workflow" "github_events" {
+  project         = google_project_service.workflows.project
+  name            = "github_events"
+  service_account = google_service_account.github.email
+  source_contents = file("../workflows/github/events.workflows.yml")
+}

--- a/terraform/raw_data.tf
+++ b/terraform/raw_data.tf
@@ -7,10 +7,17 @@ resource "google_logging_project_sink" "raw_data" {
   destination            = "bigquery.googleapis.com/${google_bigquery_dataset.raw_data.id}"
   unique_writer_identity = true
   filter                 = <<-EOT
-    logName="projects/qcmautomator/logs/Workflows"
-    resource.type="workflows.googleapis.com/Workflow"
-    resource.labels.workflow_id="${google_workflows_workflow.fitbit_sleep.name}"
-    jsonPayload.fitbit_sleep_v1:*
+    (
+      logName="projects/qcmautomator/logs/Workflows"
+      resource.type="workflows.googleapis.com/Workflow"
+      resource.labels.workflow_id="${google_workflows_workflow.fitbit_sleep.name}"
+      jsonPayload.fitbit_sleep_v1:*
+    ) OR (
+      logName="projects/qcmautomator/logs/Workflows"
+      resource.type="workflows.googleapis.com/Workflow"
+      resource.labels.workflow_id="${google_workflows_workflow.github_events.name}"
+      jsonPayload.github_event_v1:*
+    )
   EOT
   bigquery_options {
     use_partitioned_tables = true

--- a/terraform/workflows.tf
+++ b/terraform/workflows.tf
@@ -22,8 +22,9 @@ resource "google_workflows_workflow" "hourly" {
   source_contents = file("../workflows/hourly.workflows.yml")
 
   user_env_vars = {
-    FITBIT_SLEEP_WORKFLOW_ID = google_workflows_workflow.fitbit_sleep.name
-    GOODREADS_CLOUD_RUN_ID   = google_cloud_run_v2_job.fetch_goodreads.id
+    FITBIT_SLEEP_WORKFLOW_ID  = google_workflows_workflow.fitbit_sleep.name
+    GITHUB_EVENTS_WORKFLOW_ID = google_workflows_workflow.github_events.name
+    GOODREADS_CLOUD_RUN_ID    = google_cloud_run_v2_job.fetch_goodreads.id
   }
 }
 

--- a/workflows/github/events.workflows.yml
+++ b/workflows/github/events.workflows.yml
@@ -1,0 +1,59 @@
+main:
+  params: [args]
+  steps:
+    - init:
+        assign:
+          - path_or_url: "/users/cmc333333/events?per_page=10"
+    - fetch_one_page:
+        call: github_api
+        args:
+          path_or_url: ${path_or_url}
+        result: result
+    - log_results:
+        for:
+          value: event
+          in: ${result.body}
+          steps:
+            - log_event:
+                call: sys.log
+                args:
+                  json:
+                    github_event_v1: ${event}
+    - check_if_done:
+        switch:
+          - condition: ${parse_next_link(result.headers.Link) != ""}
+            assign:
+              - path_or_url: ${parse_next_link(result.headers.Link)}
+            next: fetch_one_page
+
+github_api:
+  params: [path_or_url, body: null, query: null, method: GET]
+  steps:
+    - init:
+        assign:
+          - url: ${if(text.substring(path_or_url, 0, 1) == "/", "https://api.github.com" + path_or_url, path_or_url)}
+    - hit:
+        call: http.request
+        args:
+          body: ${body}
+          headers:
+            Authorization: ${"Bearer " + googleapis.secretmanager.v1.projects.secrets.versions.accessString("github_token")}
+          method: ${method}
+          query: ${query}
+          url: ${url}
+        result: result
+    - return:
+        return: ${result}
+
+parse_next_link:
+  params: [next_header]
+  steps:
+    - find_matches:
+        assign:
+          - matches: ${text.find_all_regex(next_header, "<[^>]+>; rel=\"next\"")}
+    - branch:
+        switch:
+          - condition: ${len(matches) > 0}
+            return: ${text.replace_all_regex(matches[0].match, "^.*<|>.*$", "")}
+          - condition: true
+            return: ""

--- a/workflows/hourly.workflows.yml
+++ b/workflows/hourly.workflows.yml
@@ -14,9 +14,17 @@ main:
               project_id: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
               location: ${sys.get_env("GOOGLE_CLOUD_LOCATION")}
               workflow_id: ${sys.get_env("FITBIT_SLEEP_WORKFLOW_ID")}
-    - goodreads:
+    - github_events:
         switch:
           - condition: ${hour == 2}
+            call: googleapis.workflowexecutions.v1.projects.locations.workflows.executions.run
+            args:
+              project_id: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+              location: ${sys.get_env("GOOGLE_CLOUD_LOCATION")}
+              workflow_id: ${sys.get_env("GITHUB_EVENTS_WORKFLOW_ID")}
+    - goodreads:
+        switch:
+          - condition: ${hour == 3}
             call: googleapis.run.v2.projects.locations.jobs.run
             args:
               name: ${sys.get_env("GOODREADS_CLOUD_RUN_ID")}


### PR DESCRIPTION
GitHub says this API only goes back 90 days.

This'll dump plenty of duplicate rows, so those'll need to be cleaned up in some later step.